### PR TITLE
remove android:allowBackup="true" from Manifest

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,10 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.jimulabs.motionkit">
 
-    <application android:allowBackup="true"
-                 android:label="@string/app_name"
-        >
-
-    </application>
+    <application android:label="@string/app_name"/>
 
 </manifest>


### PR DESCRIPTION
Currently, the AndroidManifest contains `android:allowBackup="true"`. We should remove this attribute as it is not something a library project should decide and it causes the mergeManifest to fail on projects that requires `android:allowBackup="false"`.

Usually, using `tools:replace="android:allowBackup"` in the Manifest of the main project should fix issue, but `replace` doesn't currently work with `allowBackup`. See https://code.google.com/p/android/issues/detail?id=70073.

Looks like the best thing to do is just to remove it from library manifest. 

WalkAround: import the library manually and remove the attribute.
